### PR TITLE
Set collation_connection on connection init

### DIFF
--- a/jobs/mysql_node/templates/my.cnf.erb
+++ b/jobs/mysql_node/templates/my.cnf.erb
@@ -21,6 +21,7 @@ log-error = /var/vcap/sys/log/mysql/mysqld.err.log
 [mysqld]
 collation_server        = utf8_unicode_ci
 character_set_server    = utf8
+init_connect    = 'SET collation_connection = utf8_unicode_ci'
 user		= vcap
 socket		= <%= "#{base_folder}/mysqld.sock" %>
 port     	= 3306

--- a/jobs/mysql_node/templates/my55.cnf.erb
+++ b/jobs/mysql_node/templates/my55.cnf.erb
@@ -21,6 +21,7 @@ log-error = /var/vcap/sys/log/mysql/mysqld55.err.log
 [mysqld]
 collation_server        = utf8_unicode_ci
 character_set_server    = utf8
+init_connect    = 'SET collation_connection = utf8_unicode_ci'
 user		                = vcap
 socket		              = <%= "#{base_folder}/mysqld55.sock" %>
 port     	              = 3307


### PR DESCRIPTION
When I provisioned a mysql database on the mysql_node to use with my rails application I run into the following error: `ActiveRecord::StatementInvalid (Mysql2::Error: Illegal mix of collations (utf8_general_ci,IMPLICIT) and (utf8_unicode_ci,IMPLICIT) for operation '=':`
I found out that the `collation_connection` was set to `utf8_general_ci`.
I was not able to change this connection at the rails side because I'm using the [cf-autoconfig](https://github.com/cloudfoundry/vcap-ruby/tree/master/auto-reconfiguration) gem.
And as a result the database.yml file is ignored.
